### PR TITLE
Make date strings present the same in V2 and V3

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -125,16 +125,27 @@ export const App = () => {
       ]);
 
       const completeSolarRecords = solarEvents.map(solarEvent => {
-        return {
+        const record: { [key: string]: any } = {
           latitude: Number(latitude),
           longitude: Number(longitude),
           location: location?.name,
-          day: selectedAttrs.includes("day") ? solarEvent.day : "",
-          sunrise: selectedAttrs.includes("sunrise") ? solarEvent.sunrise : "",
-          sunset: selectedAttrs.includes("sunset") ? solarEvent.sunset : "",
-          dayLength: selectedAttrs.includes("dayLength") ? solarEvent.dayLength : "",
           dayAsInteger: solarEvent.dayAsInteger
         };
+
+        if (selectedAttrs.includes("day")) {
+          record.day = solarEvent.day;
+        }
+        if (selectedAttrs.includes("sunrise")) {
+          record.sunrise = solarEvent.sunrise;
+        }
+        if (selectedAttrs.includes("sunset")) {
+          record.sunset = solarEvent.sunset;
+        }
+        if (selectedAttrs.includes("dayLength")) {
+          record.dayLength = solarEvent.dayLength;
+        }
+
+        return record;
       });
 
       await createItems(kDataContextName, completeSolarRecords);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -129,7 +129,7 @@ export const App = () => {
       ]);
 
       const completeSolarRecords = solarEvents.map(solarEvent => {
-        const record: { [key: string]: any } = {
+        const record: Record<string, any> = {
           latitude: Number(latitude),
           longitude: Number(longitude),
           location: location?.name,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -26,6 +26,7 @@ export const App = () => {
   const [locationSearch, setLocationSearch] = useState<string>("");
   const [selectedAttrs, setSelectedAttributes] = useState<string[]>(kDefaultOnAttributes);
   const [showInfo, setShowInfo] = useState<boolean>(false);
+  const [useRealTimeZones, setUseRealTimeZones] = useState<boolean>(true);
 
   useEffect(() => {
     initializePlugin({
@@ -97,7 +98,8 @@ export const App = () => {
     const locationOptions: LocationOptions = {
       latitude: Number(latitude),
       longitude: Number(longitude),
-      year: 2024
+      year: 2024,
+      useRealTimeZones
     };
 
     const solarEvents = getDayLightInfo(locationOptions);
@@ -206,6 +208,15 @@ export const App = () => {
         <button onClick={getDayLengthData}>
           Get Data
         </button>
+        {/* Hiding the useRealTimeZones checkbox since it is not in spec yet */}
+        <div className="plugin-row real-time-zones" style={{display: "none"}}>
+          <label>Use Real Time Zones</label>
+          <input
+            type="checkbox"
+            checked={useRealTimeZones}
+            onChange={() => setUseRealTimeZones(!useRealTimeZones)}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -110,6 +110,10 @@ export const App = () => {
       setDataContext(createDC.values);
     }
 
+    // TODO: See how you managed hiding and unhiding in branch 'local-backup-of-attr-hiding-progress'
+    // It only worked for V3
+    // We can do { name: "day", type: "date", hidden: !selectedAttrs.includes("day") } initially
+    // But then will need to use UI listeners and data changes to hide and unhide attributes
     if (existingDataContext?.success || createDC?.success) {
       await createParentCollection(kDataContextName, kParentCollectionName, [
         { name: "latitude", type: "numeric" },

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -129,10 +129,10 @@ export const App = () => {
           latitude: Number(latitude),
           longitude: Number(longitude),
           location: location?.name,
-          day: selectedAttrs.includes("day") ? solarEvent.day : null,
-          sunrise: selectedAttrs.includes("sunrise") ? solarEvent.sunrise : null,
-          sunset: selectedAttrs.includes("sunset") ? solarEvent.sunset : null,
-          dayLength: selectedAttrs.includes("dayLength") ? solarEvent.dayLength : null,
+          day: selectedAttrs.includes("day") ? solarEvent.day : "",
+          sunrise: selectedAttrs.includes("sunrise") ? solarEvent.sunrise : "",
+          sunset: selectedAttrs.includes("sunset") ? solarEvent.sunset : "",
+          dayLength: selectedAttrs.includes("dayLength") ? solarEvent.dayLength : "",
           dayAsInteger: solarEvent.dayAsInteger
         };
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,9 @@ export interface LocationOptions {
 }
 
 export interface DaylightInfo {
-  day: Date;
-  sunrise: Date;
-  sunset: Date;
+  day: string;
+  sunrise: string;
+  sunset: string;
   dayLength: number;
   dayAsInteger: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface LocationOptions {
   latitude: number;
   longitude: number;
   year: number;
+  useRealTimeZones: boolean;
 }
 
 export interface DaylightInfo {

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -26,29 +26,22 @@ export function getDayLightInfo(options: LocationOptions): DaylightInfo[] {
     const tzSunrise = utcSunrise.tz(timeZone);
     const tzSunset = utcSunset.tz(timeZone);
 
-    // const localSunriseSinceMidnight = tzSunrise.diff(tzSunrise.startOf("day"), "hour", true);
-    // const localSunsetSinceMidnight = tzSunset.diff(tzSunset.startOf("day"), "hour", true);
-    // const dayLength = localSunsetSinceMidnight - localSunriseSinceMidnight;
+    // TODO: will need to handle above arctic circle and below antarctic circle
 
     const utcMidnight = utcSunrise.startOf("day");
     const utcSunriseSinceMidnight = utcSunrise.diff(utcMidnight, "hour", true);
     const utcSunsetSinceMidnight = utcSunset.diff(utcMidnight, "hour", true);
     let dayLength = utcSunsetSinceMidnight - utcSunriseSinceMidnight;
-
-    // Handle cases where sunset is on the next day
-    if (dayLength < 0) {
-      dayLength += 24;
-    }
-
+    if (dayLength < 0) dayLength += 24;
 
     const record: DaylightInfo = {
       day: currentDay.format("YYYY-MM-DD"),
       sunrise: tzSunrise.format("YYYY-MM-DDTHH:mmZ"),
       sunset: tzSunset.format("YYYY-MM-DDTHH:mmZ"),
-      dayLength, //: dayLength > 0 ? dayLength : dayLength + 24,
+      dayLength,
       dayAsInteger: currentDay.dayOfYear()
     };
-    console.log("record!", record);
+
     results.push(record);
     currentDay = currentDay.add(1, "day");
   }

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -19,35 +19,18 @@ export function getDayLightInfo(options: LocationOptions): DaylightInfo[] {
 
   while (currentDay.isBefore(endOfYear)) {
     const date = currentDay.toDate();
+    const timeZone = tzlookup(latitude, longitude);
 
-    const userWallTimeSunrise = getSunrise(latitude, longitude, date);
-    console.log("| userWallTimeSunrise: ", userWallTimeSunrise);
-    const userWallTimeSunset = getSunset(latitude, longitude, date);
-    const utcSunrise = dayjs.utc(userWallTimeSunrise);
-    console.log("| utcSunrise: ", utcSunrise);
-    const utcSunset = dayjs.utc(userWallTimeSunset);
-
-    const targetTZSunrise: dayjs.Dayjs = useRealTimeZones
-      ? utcSunrise.tz(tzlookup(latitude, longitude))
-      : utcSunrise.add(Math.round(longitude / 15), "hour");
-
-    console.log("| targetTZSunrise: ", targetTZSunrise);
-    const codapSunrise = targetTZSunrise.format("YYYY-MM-DDTHH:mm:ss.SSS");
-    console.log("| codapSunrise: ", codapSunrise);
-
-    const targetTZSunset: dayjs.Dayjs = useRealTimeZones
-      ? utcSunset.tz(tzlookup(latitude, longitude))
-      : utcSunset.add(Math.round(longitude / 15), "hour");
-
-    const riseSinceMidnight = targetTZSunrise.diff(targetTZSunrise.startOf("day"), "hour", true);
-    const setSinceMidnight = targetTZSunset.diff(targetTZSunset.startOf("day"), "hour", true);
-    const dayLength = setSinceMidnight - riseSinceMidnight;
+    const utcSunrise = dayjs(getSunrise(latitude, longitude, date));
+    const utcSunset = dayjs(getSunset(latitude, longitude, date));
+    const tzSunrise = utcSunrise.tz(timeZone);
+    const tzSunset = utcSunset.tz(timeZone);
 
     const record: DaylightInfo = {
       day: currentDay.format("YYYY-MM-DD"),
-      sunrise: codapSunrise,
-      sunset: targetTZSunset.format("YYYY-MM-DDTHH:mm:ss.SSS"),
-      dayLength,
+      sunrise: tzSunrise.format("YYYY-MM-DDTHH:mmZ"),
+      sunset: tzSunset.format("YYYY-MM-DDTHH:mmZ"),
+      dayLength: tzSunset.diff(tzSunrise, "hour", true),
       dayAsInteger: currentDay.dayOfYear()
     };
 

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -26,14 +26,29 @@ export function getDayLightInfo(options: LocationOptions): DaylightInfo[] {
     const tzSunrise = utcSunrise.tz(timeZone);
     const tzSunset = utcSunset.tz(timeZone);
 
+    // const localSunriseSinceMidnight = tzSunrise.diff(tzSunrise.startOf("day"), "hour", true);
+    // const localSunsetSinceMidnight = tzSunset.diff(tzSunset.startOf("day"), "hour", true);
+    // const dayLength = localSunsetSinceMidnight - localSunriseSinceMidnight;
+
+    const utcMidnight = utcSunrise.startOf("day");
+    const utcSunriseSinceMidnight = utcSunrise.diff(utcMidnight, "hour", true);
+    const utcSunsetSinceMidnight = utcSunset.diff(utcMidnight, "hour", true);
+    let dayLength = utcSunsetSinceMidnight - utcSunriseSinceMidnight;
+
+    // Handle cases where sunset is on the next day
+    if (dayLength < 0) {
+      dayLength += 24;
+    }
+
+
     const record: DaylightInfo = {
       day: currentDay.format("YYYY-MM-DD"),
       sunrise: tzSunrise.format("YYYY-MM-DDTHH:mmZ"),
       sunset: tzSunset.format("YYYY-MM-DDTHH:mmZ"),
-      dayLength: tzSunset.diff(tzSunrise, "hour", true),
+      dayLength, //: dayLength > 0 ? dayLength : dayLength + 24,
       dayAsInteger: currentDay.dayOfYear()
     };
-
+    console.log("record!", record);
     results.push(record);
     currentDay = currentDay.add(1, "day");
   }

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -62,9 +62,9 @@ export function getDayLightInfo(options: LocationOptions): DaylightInfo[] {
     const dayLength = localSunsetSinceMidnight - localSunriseSinceMidnight;
 
     const record: DaylightInfo = {
-      day: currentDay.toDate(),
-      sunrise: localSunrise.toDate(),
-      sunset: localSunset.toDate(),
+      day: currentDay.toISOString(),
+      sunrise: localSunrise.toISOString(),
+      sunset: localSunset.toISOString(),
       dayLength,
       dayAsInteger: currentDay.dayOfYear()
     };

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -21,12 +21,25 @@ export function getDayLightInfo(options: LocationOptions): DaylightInfo[] {
     const date = currentDay.toDate();
     const timeZone = tzlookup(latitude, longitude);
 
+    // TODO: will need to handle above arctic circle and below antarctic circle
+    // Figure out what to pass when sun never sets or never rises
+    // Sedondarily, will need to make dayLengths 0 and 24 respectively
+
     const utcSunrise = dayjs(getSunrise(latitude, longitude, date));
     const utcSunset = dayjs(getSunset(latitude, longitude, date));
-    const tzSunrise = utcSunrise.tz(timeZone);
-    const tzSunset = utcSunset.tz(timeZone);
 
-    // TODO: will need to handle above arctic circle and below antarctic circle
+    // NOTE: we might want to rip out the fake time zone option
+    // and remove the useRealTimeZones flag entirely
+    // but for now, we keep these conditionals in place
+
+    const tzSunrise = useRealTimeZones
+      ? utcSunrise.tz(timeZone)
+      : utcSunrise.add(Math.round(longitude / 15), "hour");
+
+    const tzSunset = useRealTimeZones
+      ? utcSunset.tz(timeZone)
+      : utcSunset.add(Math.round(longitude / 15), "hour");
+
 
     const utcMidnight = utcSunrise.startOf("day");
     const utcSunriseSinceMidnight = utcSunrise.diff(utcMidnight, "hour", true);


### PR DESCRIPTION
We send CODAP date formatted as an ISO string.   
- When we do this the date in the CODAP table is rendered without double quotes in both V2 and V3. 
- Previously, we sent raw dates created with `dayJS.toDate()`.  These presented without quotes in V3, but with double quotes in V2
- This also changes the default timezone handling so that it looks up the real timezone time for the given date and location, and creates a toggle that could be used to choose a longitude based "time zone"