### PR TITLE
188027991 manage columns

### DIFF
--- a/src/components/location-tab.tsx
+++ b/src/components/location-tab.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { useDataUtils } from "../hooks/useCodapData";
+import React, { useEffect } from "react";
+import { useCodapData } from "../hooks/useCodapData";
 import { kSelectableAttributes } from "../constants";
 import { ILocation } from "../types";
 import { LocationPicker } from "./location-picker";
@@ -33,7 +33,23 @@ export const LocationTab: React.FC<LocationTabProps> = ({
   setLocationSearch,
   setSelectedAttributes
 }) => {
-  const { dataContext, handleClearData: handleClearDataClick, getDayLengthData } = useDataUtils();
+  const {
+    dataContext,
+    handleClearDataClick,
+    getDayLengthData,
+    updateAttributeVisibility
+  } = useCodapData();
+
+  useEffect(() => {
+    const updateAttributesVisibility = async () => {
+      for (const selectable of kSelectableAttributes) {
+        const isSelected = selectedAttrs.includes(selectable.attrName);
+        await updateAttributeVisibility(selectable.attrName, !isSelected);
+      }
+    };
+
+    updateAttributesVisibility();
+  }, [selectedAttrs, updateAttributeVisibility]);
 
   const handleLatChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setLatitude(event.target.value);

--- a/src/components/location-tab.tsx
+++ b/src/components/location-tab.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useCodapData } from "../hooks/useCodapData";
-import { kSelectableAttributes } from "../constants";
+import { kChildCollectionAttributes } from "../constants";
 import { ILocation } from "../types";
 import { LocationPicker } from "./location-picker";
 
@@ -42,9 +42,9 @@ export const LocationTab: React.FC<LocationTabProps> = ({
 
   useEffect(() => {
     const updateAttributesVisibility = async () => {
-      for (const selectable of kSelectableAttributes) {
-        const isSelected = selectedAttrs.includes(selectable.attrName);
-        await updateAttributeVisibility(selectable.attrName, !isSelected);
+      for (const attr of kChildCollectionAttributes) {
+        const isSelected = selectedAttrs.includes(attr.name);
+        await updateAttributeVisibility(attr.name, !isSelected);
       }
     };
 
@@ -86,7 +86,7 @@ export const LocationTab: React.FC<LocationTabProps> = ({
   };
 
   const handleGetDetaClick = () => {
-    getDayLengthData(Number(latitude), Number(longitude), location, selectedAttrs);
+    getDayLengthData(Number(latitude), Number(longitude), location);
   };
 
   return (
@@ -120,13 +120,13 @@ export const LocationTab: React.FC<LocationTabProps> = ({
       <div className="plugin-row attributes-selection">
         <label>Attributes</label>
         <ul className="attribute-tokens">
-          {kSelectableAttributes.map((selectable: any, index: number) => (
+          {kChildCollectionAttributes.map((attr: any, i: number) => (
             <li
-              key={index}
-              className={`token ${selectedAttrs.includes(selectable.attrName) ? "on" : "off"}`}
-              onClick={() => handleTokenClick(selectable.attrName)}
+              key={i}
+              className={`token ${selectedAttrs.includes(attr.name) ? "on" : "off"}`}
+              onClick={() => handleTokenClick(attr.name)}
             >
-              {selectable.string}
+              {attr.title}
             </li>
           ))}
         </ul>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,26 +15,51 @@ export const kParentCollectionName = "Locations";
 export const kChildCollectionName = "Daylight Info";
 
 export const kParentCollectionAttributes = [
-  { name: "latitude", type: "numeric" },
-  { name: "longitude", type: "numeric" },
-  { name: "location", type: "categorical" }
+  {
+    name: "latitude",
+    type: "numeric"
+  },
+  {
+    name: "longitude",
+    type: "numeric"
+
+  },
+  {
+    name: "location",
+    type: "categorical"
+
+  }
+  // NOTE: If data are to be historical, add year attribute
 ];
 
 export const kChildCollectionAttributes = [
-  { name: "day", type: "date" },
-  { name: "sunrise", type: "date" },
-  { name: "sunset", type: "date" },
-  { name: "dayLength", type: "numeric" },
-  { name: "dayAsInteger", type: "numeric" }
-];
-
-export const kSelectableAttributes = [
-  { string: "Day", attrName: "day" },
-  { string: "Rise hour", attrName: "sunrise" },
-  { string: "Set hour", attrName: "sunset" },
-  { string: "Day Length", attrName: "dayLength" },
+  {
+    name: "date",
+    title: "Date",
+    type: "date"
+  },
+  {
+    name: "sunrise",
+    title: "Sunrise",
+    type: "date"
+  },
+  {
+    name: "sunset",
+    title: "Sunset",
+    type: "date"
+  },
+  {
+    name: "dayLength",
+    title: "Day Length",
+    type: "numeric"
+  },
+  {
+    name: "dayNumber",
+    title: "Day Number",
+    type: "numeric"
+  }
 ];
 
 export const kDefaultOnAttributes = [
-  "day", "sunrise", "sunset", "dayLength"
+  "date", "sunrise", "sunset", "dayLength"
 ];

--- a/src/hooks/useCodapData.ts
+++ b/src/hooks/useCodapData.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { kDataContextName, kChildCollectionName, kParentCollectionName } from "../constants";
+import { kDataContextName, kChildCollectionName, kParentCollectionName, kParentCollectionAttributes, kChildCollectionAttributes } from "../constants";
 import { DaylightCalcOptions } from "../types";
 import { getDayLightInfo } from "../utils/daylight-utils";
 import {
@@ -30,7 +30,7 @@ export const useCodapData = () => {
     }
   };
 
-  const getDayLengthData = async (latitude: number, longitude: number, location: any, selectedAttrs: string[]) => {
+  const getDayLengthData = async (latitude: number, longitude: number, location: any) => {
     if (!latitude || !longitude) {
       alert("Please enter both latitude and longitude.");
       return;
@@ -53,26 +53,25 @@ export const useCodapData = () => {
     }
 
     if (existingDataContext?.success || createDC?.success) {
-      await createParentCollection(kDataContextName, kParentCollectionName, [
-        { name: "latitude", type: "numeric" },
-        { name: "longitude", type: "numeric" },
-        { name: "location", type: "categorical" }
-      ]);
-      await createChildCollection(kDataContextName, kChildCollectionName, kParentCollectionName, [
-        { name: "day", type: "date" },
-        { name: "sunrise", type: "date" },
-        { name: "sunset", type: "date" },
-        { name: "dayLength", type: "numeric" },
-        { name: "dayAsInteger", type: "numeric" }
-      ]);
+      await createParentCollection(
+        kDataContextName,
+        kParentCollectionName,
+        kParentCollectionAttributes
+      );
+      await createChildCollection(
+        kDataContextName,
+        kChildCollectionName,
+        kParentCollectionName,
+        kChildCollectionAttributes
+      );
 
       const completeSolarRecords = solarEvents.map(solarEvent => {
         const record: Record<string, any> = {
           latitude: Number(latitude),
           longitude: Number(longitude),
           location: location?.name,
-          dayAsInteger: solarEvent.dayAsInteger,
-          day: solarEvent.day,
+          dayNumber: solarEvent.dayAsInteger,
+          date: solarEvent.day,
           sunrise: solarEvent.sunrise,
           sunset: solarEvent.sunset,
           dayLength: solarEvent.dayLength

--- a/src/hooks/useCodapData.ts
+++ b/src/hooks/useCodapData.ts
@@ -9,13 +9,14 @@ import {
   createTable,
   createDataContext,
   createParentCollection,
-  createChildCollection
+  createChildCollection,
+  updateAttribute
 } from "@concord-consortium/codap-plugin-api";
 
-export const useDataUtils = () => {
+export const useCodapData = () => {
   const [dataContext, setDataContext] = useState<any>(null);
 
-  const handleClearData = async () => {
+  const handleClearDataClick = async () => {
     let result = await getDataContext(kDataContextName);
     if (result.success) {
       let dc = result.values;
@@ -94,9 +95,26 @@ export const useDataUtils = () => {
     }
   };
 
+  const updateAttributeVisibility = async (attributeName: string, hidden: boolean) => {
+    if (!dataContext) return;
+
+    try {
+      await updateAttribute(
+        kDataContextName,
+        kChildCollectionName,
+        attributeName,
+        { name: attributeName },
+        { hidden }
+      );
+    } catch (error) {
+      console.error("Error updating attribute visibility:", error);
+    }
+  };
+
   return {
     dataContext,
-    handleClearData,
+    updateAttributeVisibility,
+    handleClearDataClick,
     getDayLengthData
   };
 };

--- a/src/hooks/useCodapData.ts
+++ b/src/hooks/useCodapData.ts
@@ -71,21 +71,12 @@ export const useCodapData = () => {
           latitude: Number(latitude),
           longitude: Number(longitude),
           location: location?.name,
-          dayAsInteger: solarEvent.dayAsInteger
+          dayAsInteger: solarEvent.dayAsInteger,
+          day: solarEvent.day,
+          sunrise: solarEvent.sunrise,
+          sunset: solarEvent.sunset,
+          dayLength: solarEvent.dayLength
         };
-
-        if (selectedAttrs.includes("day")) {
-          record.day = solarEvent.day;
-        }
-        if (selectedAttrs.includes("sunrise")) {
-          record.sunrise = solarEvent.sunrise;
-        }
-        if (selectedAttrs.includes("sunset")) {
-          record.sunset = solarEvent.sunset;
-        }
-        if (selectedAttrs.includes("dayLength")) {
-          record.dayLength = solarEvent.dayLength;
-        }
 
         return record;
       });


### PR DESCRIPTION
This improves the control of the CODAP columns from the plugin UI as described in PT-188027991
- Makes attribute names and tokens more consistent
- Attribute tokens now control the visibility of CODAP columns (in other words turning an attribute "off" hides it rather than  not-calculating it)
- Internally this simplifies the constants and interfaces driving the creation and maintenance of attributes