### PR TITLE
Wrap up Ground View and add Solar Intensity calculation

### DIFF
--- a/src/grasp-seasons/3d-views/ground-rays-view.ts
+++ b/src/grasp-seasons/3d-views/ground-rays-view.ts
@@ -1,6 +1,7 @@
 import $ from "jquery";
-import { sunrayAngle } from "../utils/solar-system-data";
 import { colorInterpolation } from "../utils/utils";
+import { kEarthTilt } from "../../constants";
+import { getSunrayAngleInDegrees } from "../../utils/daylight-utils";
 
 const DEG_2_RAD = Math.PI / 180;
 
@@ -75,7 +76,7 @@ export default class {
   }
 
   get solarAngle() {
-    return sunrayAngle(this.props.day, this.props.earthTilt, this.props.lat) * DEG_2_RAD;
+    return getSunrayAngleInDegrees(this.props.day, this.props.earthTilt ? kEarthTilt : 0, this.props.lat) * DEG_2_RAD;
   }
 
   get polarNight() {
@@ -109,7 +110,7 @@ export default class {
         this.ctx.save();
         this.ctx.translate(x, skyHeight);
         this.drawLine(lineRotationRadians, 5, maxLength);
-        this.drawArrow(lineRotationRadians);
+        this.drawArrow(lineRotationRadians, 0.7, 0.7);
         this.ctx.restore();
       }
     }
@@ -174,7 +175,7 @@ export default class {
 
   drawLine(angle: any, lengthAdjustment: any, length: any) {
     this.ctx.save();
-    this.ctx.lineWidth = 4;
+    this.ctx.lineWidth = 2;
     this.ctx.rotate(angle);
     this.ctx.beginPath();
     this.ctx.moveTo(0, -lengthAdjustment);
@@ -191,7 +192,7 @@ export default class {
     this.ctx.beginPath();
     this.ctx.moveTo(0, 0);
     this.ctx.lineTo(-10, -20);
-    this.ctx.lineTo(0, -16);
+    this.ctx.lineTo(0, -20);
     this.ctx.lineTo(10, -20);
     this.ctx.lineTo(0, 0);
     this.ctx.fill();

--- a/src/grasp-seasons/components/seasons.scss
+++ b/src/grasp-seasons/components/seasons.scss
@@ -22,6 +22,7 @@ body {
 
   .right-col {
     width: 280px;
+    position: relative;
   }
 
   .left-col, .right-col {
@@ -52,6 +53,18 @@ body {
   .ground-view-label {
     margin-top: 5px;
     margin-bottom: 5px;
+  }
+
+  .sunlight-at-noon {
+    position: absolute;
+    top: 36px;
+    width: 126px;
+    height: 24px;
+    border-radius: 12px;
+    background-color: rgba(255, 255, 255, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .ground-view {

--- a/src/grasp-seasons/components/seasons.tsx
+++ b/src/grasp-seasons/components/seasons.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, ChangeEvent, useCallback } from "react";
 import Slider from "./slider/slider";
+import { getSolarNoonIntensity } from "../../utils/daylight-utils";
 import InfiniteDaySlider from "./slider/infinite-day-slider";
 import CitySelect from "./city-select";
 import getURLParam from "../utils/utils";
@@ -159,7 +160,7 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
     });
   };
 
-  const solarIntensityValue = 123; // TODO: Calculate solar intensity using lat, long, and time
+  const solarIntensityValue = getSolarNoonIntensity(simState.day, simState.lat).toFixed(2);
 
   return (
     <div className="grasp-seasons">
@@ -206,6 +207,7 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
         <div className="ground-view">
           <RaysViewComp type="ground" simulation={simState} onSimStateChange={handleSimStateChange} />
         </div>
+        <div className="sunlight-at-noon">{ t("~SUNLIGHT_AT_NOON", simLang) }</div>
         <div className="solar-intensity">
           <label>{ t("~SOLAR_INTENSITY", simLang) }: </label>
           { solarIntensityValue } { t("~SOLAR_INTENSITY_UNIT", simLang) }

--- a/src/grasp-seasons/translation/en-us.ts
+++ b/src/grasp-seasons/translation/en-us.ts
@@ -48,7 +48,7 @@ export default {
 
   // Day Length Plugin
   "~GROUND_VIEW": "Ground View",
-  "~SUNLIGHT_AT_NOOT": "Sunlight at Noon",
+  "~SUNLIGHT_AT_NOON": "Sunlight at Noon",
   "~SOLAR_INTENSITY": "Solar Intensity",
   "~SOLAR_INTENSITY_UNIT": "Watts/m²",
   "~MY_LOCATIONS": "My Locations",

--- a/src/grasp-seasons/translation/es-es.ts
+++ b/src/grasp-seasons/translation/es-es.ts
@@ -48,7 +48,7 @@ export default {
 
     // Day Length Plugin
     "~GROUND_VIEW": "Vista del suelo",
-    "~SUNLIGHT_AT_NOOT": "Luz solar al mediodía",
+    "~SUNLIGHT_AT_NOON": "Luz solar al mediodía",
     "~SOLAR_INTENSITY": "Intensidad solar",
     "~SOLAR_INTENSITY_UNIT": "Vatios/m²",
     "~MY_LOCATIONS": "Mis localizaciones",

--- a/src/grasp-seasons/utils/solar-system-data.ts
+++ b/src/grasp-seasons/utils/solar-system-data.ts
@@ -23,16 +23,18 @@ export function earthEllipseLocationByDay(day: any) {
   return new THREE.Vector3(x, 0, z);
 }
 
-export function sunrayAngle(day: number, earthTilt: number, lat: number) {
-  // Angle of tilt axis, looked at from above (i.e., projected onto xy plane).
-  // June solstice = 0, September equinox = pi/2, December solstice = pi, March equinox = 3pi/2.
-  const tiltAxisZRadians = 2 * Math.PI * (day - SUMMER_SOLSTICE) / 365;
-  // How much is a given latitude tilted up (+) or down (-) toward the ecliptic?
-  // -23.5 degrees on June solstice, 0 degrees at equinoxes, +23.5 degrees on December solstice.
-  const orbitalTiltDegrees = earthTilt ? EARTH_TILT * RAD_2_DEG : 0;
-  const effectiveTiltDegrees = -Math.cos(tiltAxisZRadians) * orbitalTiltDegrees;
-  return 90 - (lat + effectiveTiltDegrees);
-}
+// Use `getSunrayAngleInDegrees` from src/utils/daylight-utils.ts instead so we guarantee the same result in the
+// ground view and in the calculated values in the CODAP table.
+// export function sunrayAngle(day: number, earthTilt: number, lat: number) {
+//   // Angle of tilt axis, looked at from above (i.e., projected onto xy plane).
+//   // June solstice = 0, September equinox = pi/2, December solstice = pi, March equinox = 3pi/2.
+//   const tiltAxisZRadians = 2 * Math.PI * (day - SUMMER_SOLSTICE) / 365;
+//   // How much is a given latitude tilted up (+) or down (-) toward the ecliptic?
+//   // -23.5 degrees on June solstice, 0 degrees at equinoxes, +23.5 degrees on December solstice.
+//   const orbitalTiltDegrees = earthTilt ? EARTH_TILT * RAD_2_DEG : 0;
+//   const effectiveTiltDegrees = -Math.cos(tiltAxisZRadians) * orbitalTiltDegrees;
+//   return 90 - (lat + effectiveTiltDegrees);
+// }
 
 export function angleToDay(angle: number, earthTilt: number, lat: number) {
   // Inverse sunrayAngle function.

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -57,7 +57,7 @@ function getSeasonName(dayJsDay: Dayjs, latitude: number): string {
   return season;
 }
 
-function getSolarNoonIntensity(dayNum: number, latitude: number): number {
+export function getSolarNoonIntensity(dayNum: number, latitude: number): number {
   const solarConstant = 1361;
   const latitudeRad = latitude * Math.PI / 180;
   const declination = 23.45 * Math.sin((360/365) * (dayNum - 81) * Math.PI / 180);
@@ -73,7 +73,7 @@ function getSolarNoonIntensity(dayNum: number, latitude: number): number {
   return Math.max(0, solarNoonIntensity); // Ensure non-negative value
 }
 
-function getSunrayAngleInDegrees(dayNum: number, earthTilt: number, lat:number): number {
+export function getSunrayAngleInDegrees(dayNum: number, earthTilt: number, lat:number): number {
   const tiltAxisZRadians = 2 * Math.PI * (dayNum - kBasicSummerSolstice) / 365;
   const orbitalTiltDegrees = earthTilt ? earthTilt : 0;
   const effectiveTiltDegrees = -Math.cos(tiltAxisZRadians) * orbitalTiltDegrees;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
 const os = require('os');
+const { cli } = require("webpack-dev-server");
 
 // DEPLOY_PATH is set by the s3-deploy-action its value will be:
 // `branch/[branch-name]/` or `version/[tag-name]/`
@@ -25,6 +26,9 @@ module.exports = (env, argv) => {
         key: path.resolve(os.homedir(), '.localhost-ssl/localhost.key'),
         cert: path.resolve(os.homedir(), '.localhost-ssl/localhost.pem'),
       },
+      client: {
+        overlay: false
+      }
     },
     devtool: devMode ? 'eval-cheap-module-source-map' : 'source-map',
     entry: './src/index.tsx',


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/188059216

This PR implements final styling from Micheal's specs (arrow shape, label, etc.), adds Sunlight at Noon label, and Solar Intensity calculations.

I've removed duplicated sunray angle calculations so we can be sure we always use the same value.
Also, updated webpack config to disable overlay, as it's annoying here as each failed communication with CODAP triggers this overlay (and probably it won't make sense to handle errors absolutely everywhere). That way I can easily work on the plugin without CODAP.