### PR TITLE
Setup Earth Close-up view and implement animation between it and Orbit view

### DIFF
--- a/src/grasp-seasons/3d-models/earth.ts
+++ b/src/grasp-seasons/3d-models/earth.ts
@@ -3,7 +3,6 @@ import * as data from "../utils/solar-system-data";
 import * as c from "./constants";
 import earthLargeImg from "../assets/earth-2k.jpg";//'../assets/earth-grid-2k.jpg';
 import earthLargeGridImg from "../assets/earth-grid-2k.jpg";
-import earthSimpleImg from "../assets/earth-equator-0.5k.jpg";//'../assets/earth-0.5k.jpg';
 import earthBumpImg from "../assets/earth-bump-2k.jpg";
 import { IModelParams } from "../types";
 // import earthSpecularImg from '../assets/earth-specular-2k.png';
@@ -24,11 +23,9 @@ export default class Earth {
     const geometry = new THREE.SphereGeometry(RADIUS, 64, 64);
     this._material = new THREE.MeshPhongMaterial(COLORS);
     const textureLoader = new THREE.TextureLoader();
-    this._material.map = textureLoader.load(simple ? earthSimpleImg : earthLargeImg);
-    if (!simple) {
-      this._material.bumpMap = textureLoader.load(earthBumpImg);
-      this._material.bumpScale = 100000 * c.SF;
-    }
+    this._material.map = textureLoader.load(earthLargeImg);
+    this._material.bumpMap = textureLoader.load(earthBumpImg);
+    this._material.bumpScale = 100000 * c.SF;
     this._earthObject = new THREE.Mesh(geometry, this._material);
     this._orbitRotationObject = new THREE.Object3D();
     this._orbitRotationObject.add(this._earthObject);

--- a/src/grasp-seasons/3d-views/base-view.ts
+++ b/src/grasp-seasons/3d-views/base-view.ts
@@ -137,7 +137,7 @@ export default class BaseView {
     }
   }
 
-  registerInteractionHandler(handler: BaseInteraction) {
+  registerInteractionHandler(handler: BaseInteraction | null) {
     this._interactionHandler = handler;
   }
 

--- a/src/grasp-seasons/components/seasons.scss
+++ b/src/grasp-seasons/components/seasons.scss
@@ -35,6 +35,7 @@ body {
     width: 378px;
     height: 374px;
     position: relative;
+    color: #fff;
 
     .playback-controls {
       position: absolute;
@@ -42,10 +43,22 @@ body {
       left: 10px;
       display: flex;
       flex-direction: row;
-      color: #fff;
 
       label {
         font-weight: normal;
+      }
+    }
+
+    .view-type-dropdown {
+      position: absolute;
+      top: 10px;
+      display: flex;
+      justify-content: center;
+      width: 100%;
+
+      select {
+        margin-left: 7px;
+        width: 150px;
       }
     }
   }

--- a/src/grasp-seasons/components/seasons.tsx
+++ b/src/grasp-seasons/components/seasons.tsx
@@ -27,8 +27,14 @@ const DEFAULT_SIM_STATE: ISimState = {
   sunrayDistMarker: false,
   dailyRotation: false,
   earthGridlines: false,
+  lang: "en_us",
+  // -- Day Length Plugin extra state ---
+  // It could be ported back to GRASP Seasons too to handle camera model cleaner way.
   showCamera: false,
-  lang: "en_us"
+  // A new type of view where the camera is locked on Earth. It is different from GRASP Seasons Earth View because the
+  // camera follows Earth's position but does not rotate. As the year passes, we'll see different parts of Earth,
+  // including its night side. This is useful for keeping the Earth's axis constant.
+  earthCloseUpView: false,
 };
 
 function capitalize(string: string) {
@@ -83,7 +89,7 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
 
   // Derived state
   const simLang = simState.lang;
-  const playStopLabel = mainAnimationStarted ? t("~STOP", simLang) : t("~PLAY", simLang);
+  const playStopLabel = mainAnimationStarted ? t("~STOP", simLang) : t("~ORBIT_BUTTON", simLang);
 
   // Log helpers
   const logCheckboxChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -160,6 +166,11 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
     });
   };
 
+  const handleViewChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const earthCloseUpView = event.target.value === "true";
+    setSimState(prevState => ({ ...prevState, earthCloseUpView }));
+  }
+
   const solarIntensityValue = getSolarNoonIntensity(simState.day, simState.lat).toFixed(2);
 
   return (
@@ -169,6 +180,14 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
           <OrbitViewComp
             ref={orbitViewRef} simulation={simState} onSimStateChange={handleSimStateChange} log={log} showCamera={false}
           />
+          <div className="view-type-dropdown">
+            <label>{ t("~VIEW", simLang) }
+              <select value={simState.earthCloseUpView.toString()} onChange={handleViewChange}>
+                <option value="false">{ t("~EARTH_ORBIT", simLang) }</option>
+                <option value="true">{ t("~EARTH_CLOSE_UP", simLang) }</option>
+              </select>
+            </label>
+          </div>
           <div className="playback-controls">
             <button
               className="btn btn-default animation-btn"

--- a/src/grasp-seasons/translation/en-us.ts
+++ b/src/grasp-seasons/translation/en-us.ts
@@ -52,4 +52,9 @@ export default {
   "~SOLAR_INTENSITY": "Solar Intensity",
   "~SOLAR_INTENSITY_UNIT": "Watts/m²",
   "~MY_LOCATIONS": "My Locations",
+  "~VIEW": "View",
+  "~EARTH_ORBIT": "Earth Orbit",
+  "~EARTH_CLOSE_UP": "Earth Close-up",
+  "~TILT_VIEW": "Tilt View",
+  "~ORBIT_BUTTON": "Orbit",
 };

--- a/src/grasp-seasons/translation/es-es.ts
+++ b/src/grasp-seasons/translation/es-es.ts
@@ -52,4 +52,9 @@ export default {
     "~SOLAR_INTENSITY": "Intensidad solar",
     "~SOLAR_INTENSITY_UNIT": "Vatios/m²",
     "~MY_LOCATIONS": "Mis localizaciones",
+    "~VIEW": "Vista",
+    "~EARTH_ORBIT": "Órbita de la Tierra",
+    "~EARTH_CLOSE_UP": "Acercamiento a la Tierra",
+    "~TILT_VIEW": "Vista inclinada",
+    "~ORBIT_BUTTON": "Órbita",
 };

--- a/src/grasp-seasons/types.ts
+++ b/src/grasp-seasons/types.ts
@@ -12,8 +12,14 @@ export interface ISimState {
   sunrayDistMarker: boolean;
   dailyRotation: boolean;
   earthGridlines: boolean;
-  showCamera: boolean;
   lang: Language;
+  // -- Day Length Plugin extra state ---
+  // It could be ported back to GRASP Seasons too to handle camera model cleaner way.
+  showCamera: boolean;
+  // A new type of view where the camera is locked on Earth. It is different from GRASP Seasons Earth View because the
+  // camera follows Earth's position but does not rotate. As the year passes, we'll see different parts of Earth,
+  // including its night side. This is useful for keeping the Earth's axis constant.
+  earthCloseUpView: boolean;
 }
 
 export type ModelType = "earth-view" | "orbit-view" | "unknown";


### PR DESCRIPTION
This PR adds an Earth close-up view and animates the camera between these two modes. Everything should still work even if the Earth is currently moving (after the user clicks the "Play" or "Orbit" button).