### PR TITLE
store function in ref to avoid having to mention it as a dependency

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { clsx } from "clsx";
 import { ILocation } from "../types";
 import { kInitialDimensions, kVersion, kPluginName, kDefaultOnAttributes, kSimulationTabDimensions, kDataContextName } from "../constants";
@@ -21,6 +21,8 @@ export const App: React.FC = () => {
   const [dataContext, setDataContext] = useState<any>(null);
 
   const { getUniqueLocationsInCodapData } = useCodapData();
+  // Store a ref to getUniqueLocationsInCodapData so we can call inside useEffect without triggering unnecessary re-runs
+  const getUniqueLocationsRef = useRef(getUniqueLocationsInCodapData);
 
   useEffect(() => {
     const initialize = async () => {
@@ -42,7 +44,7 @@ export const App: React.FC = () => {
         const casesDeleted = values.operation === "selectCases" && values.result.cases.length === 0 && values.result.success;
 
         if ( casesDeleted ) {
-          const uniqeLocations = await getUniqueLocationsInCodapData();
+          const uniqeLocations = await getUniqueLocationsRef.current();
           if (uniqeLocations) setLocations(uniqeLocations);
         }
       };
@@ -50,7 +52,7 @@ export const App: React.FC = () => {
     };
 
     initialize();
-  }, [getUniqueLocationsInCodapData]);
+  }, []);
 
   const handleTabClick = (tab: "location" | "simulation") => {
     setActiveTab(tab);


### PR DESCRIPTION
This stores a ref to `getUniqueLocationsInCodapData` which needs to be called from a useEffect (and thus the function was supposed to be put in the dependencies).  This was causing re-renders and breaking the interaction with CODAP via the API - I think because it was trying to reinitialize each time the component re-rendered. 