### PR TITLE
187887752 date format improvements, attribute refinements

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -70,7 +70,11 @@ export const App: React.FC = () => {
         const isResource = resource === `dataContextChangeNotice[${kDataContextName}]`;
         if (!isResource) return;
 
-        const casesDeleted = values.operation === "selectCases" && values.result.cases && values.result.cases.length === 0 && values.result.success;
+        const casesDeleted =
+          values.operation === "selectCases"
+          && values.result.cases
+          && values.result.cases.length === 0
+          && values.result.success;
 
         if ( casesDeleted ) {
           const uniqeLocations = await getUniqueLocationsRef.current();

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -70,7 +70,7 @@ export const App: React.FC = () => {
         const isResource = resource === `dataContextChangeNotice[${kDataContextName}]`;
         if (!isResource) return;
 
-        const casesDeleted = values.operation === "selectCases" && values.result.cases.length === 0 && values.result.success;
+        const casesDeleted = values.operation === "selectCases" && values.result.cases && values.result.cases.length === 0 && values.result.success;
 
         if ( casesDeleted ) {
           const uniqeLocations = await getUniqueLocationsRef.current();

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -26,7 +26,7 @@ export const App: React.FC = () => {
   const [dataContext, setDataContext] = useState<any>(null);
 
   const handleDayUpdateInTheSimTab = (day: number) => {
-    console.log("The day of the year has been updated in the simulation tab to: ", day); // TODO: remove it later
+    // console.log("The day of the year has been updated in the simulation tab to: ", day); // TODO: implement this
     // We might to debounce this call, as if the animation is on, or user is dragging the slider, there will be
     // lot of events and API calls to CODAP.
     updateRowSelectionInCodap(latitude, longitude, Math.floor(day));

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -19,7 +19,7 @@ export const App: React.FC = () => {
   const [activeTab, setActiveTab] = useState<"location" | "simulation">("location");
   const [latitude, setLatitude] = useState("");
   const [longitude, setLongitude] = useState("");
-  const [dayOfYear, setDayOfYear] = useState(171);
+  const [dayOfYear, /*setDayOfYear */] = useState(171);
   const [locations, setLocations] = useState<ILocation[]>([]);
   const [locationSearch, setLocationSearch] = useState<string>("");
   const [selectedAttrs, setSelectedAttributes] = useState<string[]>(kDefaultOnAttributes);
@@ -34,20 +34,21 @@ export const App: React.FC = () => {
     // of the sync process, when user select a row in CODAP and we want to update the day in the simulation tab.
   };
 
-  const handleCaseSelectionInCodap = (_latitude: string, _longitude: string, day: number) => {
-    // Option 1. Update as much of the plugin state as we can when user selects a case in CODAP. I think this might
-    // be too much, as it'll clear all the inputs in all the tabs and the user will have to re-enter everything
-    // if they were in the middle of something.
-    // setDayOfYear(day);
-    // setLatitude(_latitude);
-    // setLongitude(_longitude);
-    // ...OR...
-    // Option 2. Update only the day of the year, as that's reasonably unobtrusive and useful. We can first check
-    // if user actually selected the case from the same location, and only then update the day of the year.
-    if (latitude === _latitude && longitude === _longitude) {
-      setDayOfYear(day);
-    }
-  }
+  // TODO: Handle case selection - sync sim tab with CODAP selection
+  // const handleCaseSelectionInCodap = (_latitude: string, _longitude: string, day: number) => {
+  //   // Option 1. Update as much of the plugin state as we can when user selects a case in CODAP. I think this might
+  //   // be too much, as it'll clear all the inputs in all the tabs and the user will have to re-enter everything
+  //   // if they were in the middle of something.
+  //   // setDayOfYear(day);
+  //   // setLatitude(_latitude);
+  //   // setLongitude(_longitude);
+  //   // ...OR...
+  //   // Option 2. Update only the day of the year, as that's reasonably unobtrusive and useful. We can first check
+  //   // if user actually selected the case from the same location, and only then update the day of the year.
+  //   if (latitude === _latitude && longitude === _longitude) {
+  //     setDayOfYear(day);
+  //   }
+  // }
 
   const { getUniqueLocationsInCodapData } = useCodapData();
   // Store a ref to getUniqueLocationsInCodapData so we can call inside useEffect without triggering unnecessary re-runs

--- a/src/components/location-tab.tsx
+++ b/src/components/location-tab.tsx
@@ -42,17 +42,16 @@ export const LocationTab: React.FC<LocationTabProps> = ({
     getUniqueLocationsInCodapData
   } = useCodapData();
 
-  // TODO - this is causing re-render issues in v2, need to address attr visibility in a different way
-  // useEffect(() => {
-  //   const updateAttributesVisibility = async () => {
-  //     for (const attr of kChildCollectionAttributes) {
-  //       const isSelected = selectedAttrs.includes(attr.name);
-  //       await updateAttributeVisibility(attr.name, !isSelected);
-  //     }
-  //   };
+  useEffect(() => {
+    const updateEachAttrVisibility = () => {
+      for (const attr of kChildCollectionAttributes) {
+        const isSelected = selectedAttrs.includes(attr.name);
+        updateAttributeVisibility(attr.name, !isSelected);
+      }
+    };
 
-  //   updateAttributesVisibility();
-  // }, [selectedAttrs, updateAttributeVisibility]);
+    updateEachAttrVisibility();
+  }, [selectedAttrs, updateAttributeVisibility]);
 
   const handleLatChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setLatitude(event.target.value);

--- a/src/components/location-tab.tsx
+++ b/src/components/location-tab.tsx
@@ -42,16 +42,17 @@ export const LocationTab: React.FC<LocationTabProps> = ({
     getUniqueLocationsInCodapData
   } = useCodapData();
 
-  useEffect(() => {
-    const updateAttributesVisibility = async () => {
-      for (const attr of kChildCollectionAttributes) {
-        const isSelected = selectedAttrs.includes(attr.name);
-        await updateAttributeVisibility(attr.name, !isSelected);
-      }
-    };
+  // TODO - this is causing re-render issues in v2, need to address attr visibility in a different way
+  // useEffect(() => {
+  //   const updateAttributesVisibility = async () => {
+  //     for (const attr of kChildCollectionAttributes) {
+  //       const isSelected = selectedAttrs.includes(attr.name);
+  //       await updateAttributeVisibility(attr.name, !isSelected);
+  //     }
+  //   };
 
-    updateAttributesVisibility();
-  }, [selectedAttrs, updateAttributeVisibility]);
+  //   updateAttributesVisibility();
+  // }, [selectedAttrs, updateAttributeVisibility]);
 
   const handleLatChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setLatitude(event.target.value);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,6 +47,13 @@ export const kChildCollectionAttributes = [
     precision: "day"
   },
   {
+    name: "monthDay",
+    title: "Day of Month",
+    type: "categorical",
+    hasToken: true,
+    formula: "monthName(date) + ' ' + dayOfMonth(date)"
+  },
+  {
     name: "dayLength",
     title: "Day Length",
     type: "numeric",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,14 +31,11 @@ export const kParentCollectionAttributes = [
   {
     name: "longitude",
     type: "numeric"
-
   },
   {
     name: "location",
     type: "categorical"
-
   }
-  // NOTE: If data are to be historical, add year attribute
 ];
 
 export const kChildCollectionAttributes = [
@@ -46,7 +43,8 @@ export const kChildCollectionAttributes = [
     name: "date",
     title: "Date",
     type: "date",
-    hasToken: true
+    hasToken: true,
+    precision: "day"
   },
   {
     name: "dayLength",
@@ -57,20 +55,20 @@ export const kChildCollectionAttributes = [
   {
     name: "sunrise",
     title: "Sunrise",
-    type: "date",
+    type: "categorical",
     hasToken: true
   },
   {
     name: "sunset",
     title: "Sunset",
-    type: "date",
+    type: "categorical",
     hasToken: true
   },
   {
     name: "dayNumber",
     title: "Day Number",
     type: "numeric",
-    hasToken: false
+    hasToken: true
   },
   {
     name: "sunlightAngle",
@@ -105,37 +103,17 @@ export const kChildCollectionAttributes = [
 ];
 
 export const kDefaultOnAttributes = [
-  "date", "sunrise", "sunset", "dayLength"
+  "date", "sunrise", "sunset", "dayLength", "season", "sunlightAngle", "solarIntensity", "sunriseMinSinceMidnight", "sunsetMinSinceMidnight", "dayNumber"
 ];
 
-// This is configurable because still have some development and iteration
-// to do in terms of best fit for v3 and v2 use cases for this plugin.
 export const kDateWithTimeFormats = {
-
-  // (UTC) Do not use unless CODAP or plugin has mechanism to translate to a given TZ
-  // 1982-01-23T10:45Z
-  asZuluISO: "YYYY-MM-DDTHH:mm[Z]",
-
-  // Use if both v2 and v3 will display clock time as expected, be okay with offset as programmatic asset
-  // 1982-01-23T10:45-07:00 (example offset -07:00)
-  asLocalISOWithTZOffset: "YYYY-MM-DDTHH:mmZ", // currently using this
-
-  // Use if truly no offset is included/needed, local time only
-  // 1982-01-23T10:45
-  asLocalISO: "YYYY-MM-DDTHH:mm",
-
-  // use if we must display time as a string AND we have a CODAP way to treat As if needed to graph etc.
-  // 10:45
-  asClockTimeString: "HH:mm",
+  asZuluISO: "YYYY-MM-DDTHH:mm[Z]",              // 1999-01-23T21:45Z
+  asLocalISOWithTZOffset: "YYYY-MM-DDTHH:mmZ",   // 1999-01-23T14:45-07:00
+  asClockTimeString: "HH:mm",                    // 14:45
+  asClockTimeStringAMPM: "h:mm a",               // 2:45 PM
 }
 
 export const kDateFormats = {
-
-  // Use if we need the real ISO date with year for graphing, etc.
-  // 1982-01-23
-  asLocalISODate: "YYYY-MM-DD", // currently using this
-
-  // Use if we must display date as a string AND we have a CODAP way to treat As if needed to graph etc.
-  // 01-23
+  asLocalISODate: "YYYY-MM-DD",
   asCalendarDateString: "MM-DD",
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -95,3 +95,35 @@ export const kChildCollectionAttributes = [
 export const kDefaultOnAttributes = [
   "date", "sunrise", "sunset", "dayLength"
 ];
+
+// This is configurable because still have some development and iteration
+// to do in terms of best fit for v3 and v2 use cases for this plugin.
+export const kDateWithTimeFormats = {
+
+  // (UTC) Do not use unless CODAP or plugin has mechanism to translate to a given TZ
+  // 1982-01-23T10:45Z
+  asZuluISO: "YYYY-MM-DDTHH:mm[Z]",
+
+  // Use if both v2 and v3 will display clock time as expected, be okay with offset as programmatic asset
+  // 1982-01-23T10:45-07:00 (example offset -07:00)
+  asLocalISOWithTZOffset: "YYYY-MM-DDTHH:mmZ", // currently using this
+
+  // Use if truly no offset is included/needed, local time only
+  // 1982-01-23T10:45
+  asLocalISO: "YYYY-MM-DDTHH:mm",
+
+  // use if we must display time as a string AND we have a CODAP way to treat As if needed to graph etc.
+  // 10:45
+  asClockTimeString: "HH:mm",
+}
+
+export const kDateFormats = {
+
+  // Use if we need the real ISO date with year for graphing, etc.
+  // 1982-01-23
+  asLocalISODate: "YYYY-MM-DD", // currently using this
+
+  // Use if we must display date as a string AND we have a CODAP way to treat As if needed to graph etc.
+  // 01-23
+  asCalendarDateString: "MM-DD",
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,6 +89,18 @@ export const kChildCollectionAttributes = [
     title: "Season",
     type: "categorical",
     hasToken: true
+  },
+  {
+    name: "sunriseMinSinceMidnight",
+    title: "Sunrise Minutes Since Midnight",
+    type: "numeric",
+    hasToken: true
+  },
+  {
+    name: "sunsetMinSinceMidnight",
+    title: "Sunset Minutes Since Midnight",
+    type: "numeric",
+    hasToken: true
   }
 ];
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,8 @@ export const kDefaultMaxRows = 4;
 export const kParentCollectionName = "Locations";
 export const kChildCollectionName = "Daylight Info";
 
+export const kAdjustSpringForwardOutlier = false;
+
 export const kParentCollectionAttributes = [
   {
     name: "latitude",
@@ -44,73 +46,79 @@ export const kChildCollectionAttributes = [
     title: "Date",
     type: "date",
     hasToken: true,
-    precision: "day"
+    precision: "day",
+    description: "Date"
   },
   {
-    name: "monthDay",
-    title: "Day of Month",
-    type: "categorical",
+    name: "Day length",
+    title: "Day length",
+    type: "numeric",
     hasToken: true,
-    formula: "monthName(date) + ' ' + dayOfMonth(date)"
+    unit: "hours",
+    description: "Day length in hours"
   },
   {
-    name: "dayLength",
-    title: "Day Length",
-    type: "numeric",
-    hasToken: true
+    name: "rawSunrise",
+    title: "rawSunrise",
+    type: "date",
+    hasToken: false,
+    hidden: true,
+    precision: "seconds",
+    description: "sunrise as date object"
   },
   {
-    name: "sunrise",
+    name: "rawSunset",
+    title: "rawSunset",
+    type: "date",
+    hasToken: false,
+    hidden: true,
+    precision: "seconds",
+    description: "sunset as date object"
+  },
+  {
+    name: "Sunrise",
     title: "Sunrise",
-    type: "categorical",
-    hasToken: true
+    type: "numeric",
+    hasToken: true,
+    unit: "decimal hours",
+    formula: "hours(rawSunrise)+minutes(rawSunrise)/60",
+    description: "time in decimal hours"
   },
   {
-    name: "sunset",
+    name: "Sunset",
     title: "Sunset",
-    type: "categorical",
-    hasToken: true
-  },
-  {
-    name: "dayNumber",
-    title: "Day Number",
     type: "numeric",
-    hasToken: true
+    hasToken: true,
+    unit: "decimal hours",
+    formula: "hours(rawSunset)+minutes(rawSunset)/60",
+    description: "time in decimal hours"
   },
   {
-    name: "sunlightAngle",
-    title: "Sunlight Angle",
+    name: "Sunlight angle",
+    title: "Sunlight angle",
     type: "numeric",
-    hasToken: true
+    hasToken: true,
+    unit: "°",
+    description: "angle in degrees of sunlight at solar noon"
   },
   {
-    name: "solarIntensity",
-    title: "Solar Intensity",
+    name: "Solar intensity",
+    title: "Solar intensity",
     type: "numeric",
-    hasToken: true
+    hasToken: true,
+    unit: "W/㎡",
+    description: "intensity of solar energy in watts per square meter at solar noon, disregarding all atmospheric effects"
   },
   {
-    name: "season",
+    name: "Season",
     title: "Season",
     type: "categorical",
-    hasToken: true
-  },
-  {
-    name: "sunriseMinSinceMidnight",
-    title: "Sunrise Minutes Since Midnight",
-    type: "numeric",
-    hasToken: true
-  },
-  {
-    name: "sunsetMinSinceMidnight",
-    title: "Sunset Minutes Since Midnight",
-    type: "numeric",
     hasToken: true
   }
 ];
 
 export const kDefaultOnAttributes = [
-  "date", "sunrise", "sunset", "dayLength", "season", "sunlightAngle", "solarIntensity", "sunriseMinSinceMidnight", "sunsetMinSinceMidnight", "dayNumber"
+  "date", "Day length"
 ];
 
 export const kDateWithTimeFormats = {
@@ -122,5 +130,4 @@ export const kDateWithTimeFormats = {
 
 export const kDateFormats = {
   asLocalISODate: "YYYY-MM-DD",
-  asCalendarDateString: "MM-DD",
 }

--- a/src/hooks/useCodapData.ts
+++ b/src/hooks/useCodapData.ts
@@ -86,11 +86,11 @@ export const useCodapData = () => {
     }
   };
 
-  const updateAttributeVisibility = async (attributeName: string, hidden: boolean) => {
+  const updateAttributeVisibility = (attributeName: string, hidden: boolean) => {
     if (!dataContext) return;
 
     try {
-      await updateAttribute(
+      updateAttribute(
         kDataContextName,
         kChildCollectionName,
         attributeName,

--- a/src/hooks/useCodapData.ts
+++ b/src/hooks/useCodapData.ts
@@ -73,7 +73,9 @@ export const useCodapData = () => {
           dayLength: solarEvent.dayLength,
           season: solarEvent.season,
           sunlightAngle: solarEvent.sunlightAngle,
-          solarIntensity: solarEvent.solarIntensity
+          solarIntensity: solarEvent.solarIntensity,
+          sunriseMinSinceMidnight: solarEvent.sunriseMinSinceMidnight,
+          sunsetMinSinceMidnight: solarEvent.sunsetMinSinceMidnight
         };
 
         return record;

--- a/src/hooks/useCodapData.ts
+++ b/src/hooks/useCodapData.ts
@@ -66,16 +66,13 @@ export const useCodapData = () => {
           latitude: location.latitude,
           longitude: location.longitude,
           location: location.name,
-          dayNumber: solarEvent.dayAsInteger,
           date: solarEvent.day,
-          sunrise: solarEvent.sunrise,
-          sunset: solarEvent.sunset,
-          dayLength: solarEvent.dayLength,
-          season: solarEvent.season,
-          sunlightAngle: solarEvent.sunlightAngle,
-          solarIntensity: solarEvent.solarIntensity,
-          sunriseMinSinceMidnight: solarEvent.sunriseMinSinceMidnight,
-          sunsetMinSinceMidnight: solarEvent.sunsetMinSinceMidnight
+          rawSunrise: solarEvent.rawSunrise,
+          rawSunset: solarEvent.rawSunset,
+          "Day length": solarEvent.dayLength,
+          "Season": solarEvent.season,
+          "Sunlight angle": solarEvent.sunlightAngle,
+          "Solar intensity": solarEvent.solarIntensity
         };
 
         return record;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface DaylightCalcOptions {
 }
 
 export interface DaylightInfo {
-  day: string;
+  day: string; // read into CODAP as an ISO date
   sunrise: string;
   sunset: string;
   dayLength: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,13 +13,13 @@ export interface DaylightCalcOptions {
 
 export interface DaylightInfo {
   day: string; // read into CODAP as an ISO date
-  sunrise: string;
-  sunset: string;
-  dayLength: number;
+  sunrise: string | null;
+  sunset: string | null;
+  dayLength?: number | null;
   dayAsInteger: number;
   season: string;
-  sunlightAngle: number;
-  solarIntensity: number;
+  sunlightAngle: number | null;
+  solarIntensity: number | null;
   sunriseMinSinceMidnight: number;
   sunsetMinSinceMidnight: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,8 @@ export interface DaylightInfo {
   season: string;
   sunlightAngle: number;
   solarIntensity: number;
+  sunriseMinSinceMidnight: number;
+  sunsetMinSinceMidnight: number;
 }
 
 export interface GeoNameSearchOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,16 +12,13 @@ export interface DaylightCalcOptions {
 }
 
 export interface DaylightInfo {
-  day: string; // read into CODAP as an ISO date
-  sunrise: string | null;
-  sunset: string | null;
-  dayLength?: number | null;
-  dayAsInteger: number;
+  day: string;          // read into CODAP as an ISO date
+  rawSunrise: string;   // read into CODAP as an ISO date
+  rawSunset: string;    // read into CODAP as an ISO date
+  dayLength: number;
   season: string;
-  sunlightAngle: number | null;
-  solarIntensity: number | null;
-  sunriseMinSinceMidnight: number | null;
-  sunsetMinSinceMidnight: number | null;
+  sunlightAngle: number;
+  solarIntensity: number;
 }
 
 export interface GeoNameSearchOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,8 @@ export interface DaylightInfo {
   season: string;
   sunlightAngle: number | null;
   solarIntensity: number | null;
-  sunriseMinSinceMidnight: number;
-  sunsetMinSinceMidnight: number;
+  sunriseMinSinceMidnight: number | null;
+  sunsetMinSinceMidnight: number | null;
 }
 
 export interface GeoNameSearchOptions {

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -84,7 +84,14 @@ export function getSolarNoonIntensity(dayNum: number, latitude: number): number 
                               Math.cos(latitudeRad) * Math.cos(declinationRad);
 
   const solarNoonIntensity = solarConstant * eccentricityFactor * cosSolarZenithAngle;
-  return solarNoonIntensity;
+
+  // Note: This calculation returns theoretical intensity at the top of the atmosphere.
+  // Negative values are clamped to zero, which
+  // represents times when the sun is below the horizon
+  // In reality, some diffuse light might still be present due to atmospheric scattering.
+  // None of the calculations in this plugin use "civil twighlight" or associated definitions
+  // For day length either, so this is consistent with the rest of the calculations.
+  return Math.max(0, solarNoonIntensity);
 }
 
 export function getSunrayAngleInDegrees(dayNum: number, earthTilt: number, lat:number): number {
@@ -96,10 +103,7 @@ export function getSunrayAngleInDegrees(dayNum: number, earthTilt: number, lat:n
 }
 
 export function getMinutesSinceMidnight(time: Dayjs): number {
-  if (!time.isValid()) {
-    return 0;
-  }
-  return time.hour() * 60 + time.minute();
+  return !time.isValid() ? 0 : time.hour() * 60 + time.minute();
 }
 
 export function getDayLightInfo(options: DaylightCalcOptions): DaylightInfo[] {

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -81,6 +81,10 @@ export function getSunrayAngleInDegrees(dayNum: number, earthTilt: number, lat:n
   return degrees;
 }
 
+export function getMinutesSinceMidnight(time: Dayjs): number {
+  return time.hour() * 60 + time.minute();
+}
+
 export function getDayLightInfo(options: DaylightCalcOptions): DaylightInfo[] {
   const { latitude, longitude, year } = options;
   const results: DaylightInfo[] = [];
@@ -109,8 +113,11 @@ export function getDayLightInfo(options: DaylightCalcOptions): DaylightInfo[] {
       dayAsInteger: currentDay.dayOfYear(),
       season: getSeasonName(currentDay, latitude),
       sunlightAngle: getSunrayAngleInDegrees(currentDay.dayOfYear(), kEarthTilt, latitude),
-      solarIntensity: getSolarNoonIntensity(currentDay.dayOfYear(), latitude)
+      solarIntensity: getSolarNoonIntensity(currentDay.dayOfYear(), latitude),
+      sunriseMinSinceMidnight: getMinutesSinceMidnight(localSunrise),
+      sunsetMinSinceMidnight: getMinutesSinceMidnight(localSunset)
     };
+    console.log("| record: ", record);
     results.push(record);
     currentDay = currentDay.add(1, "day");
   }

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -28,13 +28,14 @@ function getDayLength(sunrise: Dayjs, sunset: Dayjs): number {
   return dayLength;
 }
 
-function hasDST(latitude: number, longitude: number, year: number): boolean {
-  const timeZone = tzlookup(latitude, longitude);
-  const winterDate = dayjs.tz(`${year}-01-01`, timeZone);
-  const summerDate = dayjs.tz(`${year}-07-01`, timeZone);
+// Uncomment this to use in the DST adjustment commented out below
+// function hasDST(latitude: number, longitude: number, year: number): boolean {
+//   const timeZone = tzlookup(latitude, longitude);
+//   const winterDate = dayjs.tz(`${year}-01-01`, timeZone);
+//   const summerDate = dayjs.tz(`${year}-07-01`, timeZone);
 
-  return winterDate.utcOffset() !== summerDate.utcOffset();
-}
+//   return winterDate.utcOffset() !== summerDate.utcOffset();
+// }
 
 function getSeasonName(dayJsDay: Dayjs, latitude: number): string {
   const year = dayJsDay.year();
@@ -73,7 +74,7 @@ function getSeasonName(dayJsDay: Dayjs, latitude: number): string {
   return season;
 }
 
-export function getSolarNoonIntensity(dayNum: number, latitude: number): number | null {
+export function getSolarNoonIntensity(dayNum: number, latitude: number): number {
   const solarConstant = 1361;
   const latitudeRad = latitude * Math.PI / 180;
   const declination = 23.45 * Math.sin((360/365) * (dayNum - 81) * Math.PI / 180);
@@ -87,7 +88,7 @@ export function getSolarNoonIntensity(dayNum: number, latitude: number): number 
   return solarNoonIntensity;
 }
 
-export function getSunrayAngleInDegrees(dayNum: number, earthTilt: number, lat:number): number | null {
+export function getSunrayAngleInDegrees(dayNum: number, earthTilt: number, lat:number): number {
   const tiltAxisZRadians = 2 * Math.PI * (dayNum - kBasicSummerSolstice) / 365;
   const orbitalTiltDegrees = earthTilt ? earthTilt : 0;
   const effectiveTiltDegrees = -Math.cos(tiltAxisZRadians) * orbitalTiltDegrees;

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -154,11 +154,13 @@ export function getDayLightInfo(options: DaylightCalcOptions): DaylightInfo[] {
     }
     else {
       finalDayLength = getDayLength(localSunriseObj, localSunsetObj);
-      const tzHasDST = hasDST(latitude, longitude, year);
-      const isSpringForward = localSunriseObj.utcOffset() < localSunsetObj.utcOffset();
-      if (isSpringForward && tzHasDST) {
-        finalDayLength -= 1; // Subtract the extra hour added due to DST
-      }
+      // uncomment to pretend DST spring forward does not lose us an hour one day of year
+      // removing the outlier in places where DST transition happens post sunrise
+      // const tzHasDST = hasDST(latitude, longitude, year);
+      // const isSpringForward = localSunriseObj.utcOffset() < localSunsetObj.utcOffset();
+      // if (isSpringForward && tzHasDST) {
+      //   finalDayLength -= 1; // Subtract the extra hour added due to DST
+      // }
     }
 
     const record: DaylightInfo = {

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -79,9 +79,7 @@ export function getSolarNoonIntensity(dayNum: number, latitude: number): number 
   const declination = 23.45 * Math.sin((360/365) * (dayNum - 81) * Math.PI / 180);
   const declinationRad = declination * Math.PI / 180;
   const dayAngle = 2 * Math.PI * (dayNum - 1) / 365;
-  // correction factor for Earth's elliptical orbit
-  const eccentricityFactor = 1 + 0.033 * Math.cos(dayAngle);
-  // cosine of the solar zenith angle at solar noon
+  const eccentricityFactor = 1 + 0.033 * Math.cos(dayAngle); // correction factor for Earth's elliptical orbit
   const cosSolarZenithAngle = Math.sin(latitudeRad) * Math.sin(declinationRad) +
                               Math.cos(latitudeRad) * Math.cos(declinationRad);
 

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -107,8 +107,8 @@ export function getDayLightInfo(options: DaylightCalcOptions): DaylightInfo[] {
 
     const record: DaylightInfo = {
       day: currentDay.format(kDateFormats.asLocalISODate),
-      sunrise: localSunrise.format(kDateWithTimeFormats.asLocalISOWithTZOffset),
-      sunset: localSunset.format(kDateWithTimeFormats.asLocalISOWithTZOffset),
+      sunrise: localSunrise.format(kDateWithTimeFormats.asClockTimeStringAMPM),
+      sunset: localSunset.format(kDateWithTimeFormats.asClockTimeStringAMPM),
       dayLength: getDayLength(localSunrise, localSunset),
       dayAsInteger: currentDay.dayOfYear(),
       season: getSeasonName(currentDay, latitude),
@@ -117,7 +117,7 @@ export function getDayLightInfo(options: DaylightCalcOptions): DaylightInfo[] {
       sunriseMinSinceMidnight: getMinutesSinceMidnight(localSunrise),
       sunsetMinSinceMidnight: getMinutesSinceMidnight(localSunset)
     };
-    console.log("| record: ", record);
+
     results.push(record);
     currentDay = currentDay.add(1, "day");
   }


### PR DESCRIPTION
This makes some adjustments to address date formatting issues evident in work originating in [PT-187887752](https://www.pivotaltracker.com/story/show/187887752).  It also contains fixes that address [PT-187887752](https://www.pivotaltracker.com/story/show/187887752) and [PT-188074070](https://www.pivotaltracker.com/story/show/188074070) and [PT-188092756](https://www.pivotaltracker.com/story/show/188092756) and [PT-188045605](https://www.pivotaltracker.com/story/show/188045605)

1. The project team would like dates visible as YYYY/MM/DD
2. The project team would like clock times expressed as "decimal hours", e.g. 1:15PM = 13.25

Changes: 

- formulas are added for sunrise and sunset, and internal sunrise and sunset dates are hidden, but used in formula
- constants added for time format for clarity of purpose and iteration/testing in dev
- update of attribute visibility is now synchronous (async was resulting in unresolved promise pile up - did not try Promise.all, because timing is working fine for this feature) - this change was made because attributes were re-calculating/rendering during interaction with tokens
- we now assert cases exist when testing for a delete event (unrelated to above)
- we get times into utc earlier in calculation so we don't get one-off offsets on DLS changeover days in places that don't use DST
- we add an optional transformation to "spring forward" outliers (we can set the flag according to project team decision) 
- commenting out of stubbed items to reduce warning noise
- we set a floor of 0 for solar intensity (which may need to be reflected in sim)
- we make rows that occur in polar night or midnight sun changeovers display a logical day length

