### PR TITLE
187887881 selected row sync

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -22,6 +22,7 @@ const debouncedUpdateRowSelectionInCodap = debounce((
   // But I was unable to find an example of how to select a case by its attribute values
   // Next thing for this might be to see if the case ids might be mapped somewhere to the dayOfYear
   // It could be a more direct way to select the case rather than two api requests
+  // TODO: also right now this is only using the dayOfYear attribute to select the case, but it needs to be restricted to location
   codapInterface.sendRequest({
     action: "get",
     resource: `dataContext[${kDataContextName}].collection[${kChildCollectionName}].caseSearch[dayOfYear==${Math.floor(day)}]`
@@ -80,6 +81,7 @@ export const App: React.FC = () => {
       setDayOfYear(selectedDay);
       // TODO: this works, but CODAP is also resetting the case table so we scroll away from selected row
       // Perhaps because it is re-rendering the table with the new case selected?
+      // TODO: We might consider resetting latitude, longitude here as well to get sliders back on track
     }
   };
 
@@ -103,6 +105,9 @@ export const App: React.FC = () => {
   useEffect(() => {
     const handleDataContextChange = async (listenerRes: ClientNotification) => {
       console.log("| dataContextChangeNotice: ", listenerRes);
+      // TODO : as per discussion with team, it might be more typical (and compatible with v3 today)
+      // to use the notificaiton as catalyst to ask for state we interested in from CODAP
+      // rather than try to parse the notification for the data we need
       const { resource, values } = listenerRes;
       const isResource = resource === `dataContextChangeNotice[${kDataContextName}]`;
       if (!isResource || !values.result.success) return;

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -11,16 +11,20 @@ import { Header } from "./header";
 
 import "../assets/scss/App.scss";
 
-const updateRowSelectionInCodap = (latitude: string, longitude: string, day: number) => {
+const debouncedUpdateRowSelectionInCodap = debounce((latitude: string, longitude: string, day: number) => {
   console.log("\n| SIM day is: ", day, " so issue API request to update selected row in CODAP ",
     "\n latitude:       ", latitude,
     "\n longitude:      ", longitude,
     "\n day:            ", day,
     "\n Math.floor(day) ", Math.floor(day));
-}
 
-const debouncedUpdateRowSelection = debounce((latitude: string, longitude: string, day: number) => {
-  updateRowSelectionInCodap(latitude, longitude, Math.floor(day));
+  // Here, you would add the actual API call to update the row selection in CODAP
+  // For example:
+  // codapInterface.sendRequest({
+  //   action: "update",
+  //   resource: `dataContext[${kDataContextName}].selectionList`,
+  //   values: [{ latitude, longitude, dayOfYear: Math.floor(day) }]
+  // });
 }, 250);
 
 export const App: React.FC = () => {
@@ -34,7 +38,7 @@ export const App: React.FC = () => {
   const [dataContext, setDataContext] = useState<any>(null);
 
   const handleDayUpdateInTheSimTab = (day: number) => {
-    debouncedUpdateRowSelection(latitude, longitude, day);
+    debouncedUpdateRowSelectionInCodap(latitude, longitude, day);
     // NOTE: not need update dayOfYear state variable. It's useful only for the opposite direction
     // it's useful when user select a row in CODAP and we want to update the day in the sim
   };

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -22,7 +22,7 @@ const debouncedUpdateRowSelectionInCodap = debounce((
   // But I was unable to find an example of how to select a case by its attribute values
   // Next thing for this might be to see if the case ids might be mapped somewhere to the dayOfYear
   // It could be a more direct way to select the case rather than two api requests
-  // TODO: also right now this is only using the dayOfYear attribute to select the case, but it needs to be restricted to location
+  // TODO: Right now this is only using the dayOfYear attribute to select the case, but it needs to be restricted to location
   codapInterface.sendRequest({
     action: "get",
     resource: `dataContext[${kDataContextName}].collection[${kChildCollectionName}].caseSearch[dayOfYear==${Math.floor(day)}]`
@@ -74,7 +74,7 @@ export const App: React.FC = () => {
     currentLongitude: string,
     currentDayOfYear: number
   ) => {
-    // TODO: this is a little hacky - we cooerce the numbers to strings to compare them
+    // TODO: this is a little hacky? we cooerce the numbers to strings to compare them
     const rowInLocation = `${currentLatitude},${currentLongitude}` === `${selectedLatitude},${selectedLongitude}`;
     const newDayChoice = `${currentDayOfYear}` !== `${selectedDay}`;
     if (rowInLocation && newDayChoice) {
@@ -105,9 +105,10 @@ export const App: React.FC = () => {
   useEffect(() => {
     const handleDataContextChange = async (listenerRes: ClientNotification) => {
       console.log("| dataContextChangeNotice: ", listenerRes);
-      // TODO : as per discussion with team, it might be more typical (and compatible with v3 today)
+      // TODO: as per discussion with team, it might be more typical
       // to use the notificaiton as catalyst to ask for state we interested in from CODAP
       // rather than try to parse the notification for the data we need
+
       const { resource, values } = listenerRes;
       const isResource = resource === `dataContextChangeNotice[${kDataContextName}]`;
       if (!isResource || !values.result.success) return;
@@ -115,10 +116,12 @@ export const App: React.FC = () => {
       const casesDeleted = values.operation === "selectCases" && values.result.cases.length === 0
       const caseSelected = values.operation === "selectCases" && values.result.cases.length === 1;
 
+      // If cases were deleted, we should update the locations list
       if (casesDeleted) {
         const uniqeLocations = await getUniqueLocationsRef.current();
         if (uniqeLocations) setLocations(uniqeLocations);
       }
+      // If a case was selected, we should update the dayOfYear
       else if (caseSelected) {
         const parentCaseId = values.result.cases[0].parent;
         const selectedDay = values.result.cases[0].values.dayOfYear;
@@ -136,7 +139,6 @@ export const App: React.FC = () => {
       }
     };
     addDataContextChangeListener(kDataContextName, handleDataContextChange);
-    // TODO: this is kind of working but not sure about how to clean up the listener?
   }, [latitude, longitude, dayOfYear]);
 
   const handleTabClick = (tab: "location" | "simulation") => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef, useCallback } from "react";
 import { clsx } from "clsx";
-import { ILocation } from "../types";
+import { ICurrentDayLocation, ILocation } from "../types";
 import { debounce } from "../grasp-seasons/utils/utils";
 import { kInitialDimensions, kVersion, kPluginName, kDefaultOnAttributes, kSimulationTabDimensions, kDataContextName, kChildCollectionName } from "../constants";
 import { initializePlugin, codapInterface, selectSelf, addDataContextChangeListener, ClientNotification, getCaseByID } from "@concord-consortium/codap-plugin-api";
@@ -10,12 +10,6 @@ import { SimulationTab } from "./simulation-tab";
 import { Header } from "./header";
 
 import "../assets/scss/App.scss";
-
-interface CurrentDayLocation {
-  _latitude: string;
-  _longitude: string;
-  _dayOfYear: number;
-}
 
 const debouncedUpdateRowSelectionInCodap = debounce((
   latitude: string,
@@ -55,7 +49,7 @@ export const App: React.FC = () => {
   const [selectedAttrs, setSelectedAttributes] = useState<string[]>(kDefaultOnAttributes);
   const [dataContext, setDataContext] = useState<any>(null);
 
-  const currentDayLocationRef = useRef<CurrentDayLocation>({
+  const currentDayLocationRef = useRef<ICurrentDayLocation>({
     _latitude: "",
     _longitude: "",
     _dayOfYear: 171
@@ -154,6 +148,7 @@ export const App: React.FC = () => {
         dimensions: tab === "location" ? kInitialDimensions : kSimulationTabDimensions
       }
     }).then(() => {
+      // This brings the plugin window to the front within CODAP
       selectSelf();
     }).catch((error) => {
       console.error("Error updating dimensions or selecting self:", error);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,7 +3,7 @@ import { clsx } from "clsx";
 import { ILocation } from "../types";
 import { debounce } from "../grasp-seasons/utils/utils";
 import { kInitialDimensions, kVersion, kPluginName, kDefaultOnAttributes, kSimulationTabDimensions, kDataContextName } from "../constants";
-import { initializePlugin, codapInterface, addDataContextChangeListener, ClientNotification } from "@concord-consortium/codap-plugin-api";
+import { initializePlugin, codapInterface, selectSelf, addDataContextChangeListener, ClientNotification } from "@concord-consortium/codap-plugin-api";
 import { useCodapData } from "../hooks/useCodapData";
 import { LocationTab } from "./location-tab";
 import { SimulationTab } from "./simulation-tab";
@@ -96,6 +96,11 @@ export const App: React.FC = () => {
       values: {
         dimensions: tab === "location" ? kInitialDimensions : kSimulationTabDimensions
       }
+    }).then(() => {
+      // After updating dimensions, call selectSelf to bring the plugin to the front
+      selectSelf();
+    }).catch((error) => {
+      console.error("Error updating dimensions or selecting self:", error);
     });
   };
 

--- a/src/components/location-tab.tsx
+++ b/src/components/location-tab.tsx
@@ -35,7 +35,6 @@ export const LocationTab: React.FC<LocationTabProps> = ({
   setLocations
 }) => {
 
-
   const {
     dataContext,
     handleClearData,
@@ -43,8 +42,6 @@ export const LocationTab: React.FC<LocationTabProps> = ({
     updateAttributeVisibility,
     getUniqueLocationsInCodapData
   } = useCodapData();
-
-  console.log("| what is dataContext anyway?", typeof dataContext, {dataContext});
 
   useEffect(() => {
     const updateEachAttrVisibility = () => {
@@ -58,7 +55,6 @@ export const LocationTab: React.FC<LocationTabProps> = ({
   }, [selectedAttrs, updateAttributeVisibility]);
 
   const handleLatChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    event.stopPropagation();
     setLatitude(event.target.value);
     setLocationSearch("");
   };

--- a/src/components/location-tab.tsx
+++ b/src/components/location-tab.tsx
@@ -13,12 +13,12 @@ interface LocationTabProps {
   locations: ILocation[];
   locationSearch: string;
   selectedAttrs: string[];
-  dataContext: any; // TODO the type
+  dataContext: any; // TODO this is not being used, maybe we'll need it for querying?
   setLatitude: (latitude: string) => void;
   setLongitude: (longitude: string) => void;
   setLocationSearch: (search: string) => void;
   setSelectedAttributes: (attrs: string[]) => void;
-  setDataContext: (context: any) => void; // TODO the type
+  setDataContext: (context: any) => void; // TODO this is not being used
   setLocations: (locations: ILocation[]) => void;
 }
 
@@ -34,6 +34,7 @@ export const LocationTab: React.FC<LocationTabProps> = ({
   setSelectedAttributes,
   setLocations
 }) => {
+
   const {
     dataContext,
     handleClearData,
@@ -54,6 +55,7 @@ export const LocationTab: React.FC<LocationTabProps> = ({
   }, [selectedAttrs, updateAttributeVisibility]);
 
   const handleLatChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    event.stopPropagation();
     setLatitude(event.target.value);
     setLocationSearch("");
   };

--- a/src/components/location-tab.tsx
+++ b/src/components/location-tab.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useCodapData } from "../hooks/useCodapData";
 import { kChildCollectionAttributes } from "../constants";
-import { ILocation } from "../types";
+import { ICodapDataContextInfo, ILocation } from "../types";
 import { LocationPicker } from "./location-picker";
 import { locationsEqual } from "../utils/daylight-utils";
 
@@ -13,12 +13,12 @@ interface LocationTabProps {
   locations: ILocation[];
   locationSearch: string;
   selectedAttrs: string[];
-  dataContext: any; // TODO this is not being used, maybe we'll need it for querying?
+  dataContext: ICodapDataContextInfo | null;
   setLatitude: (latitude: string) => void;
   setLongitude: (longitude: string) => void;
   setLocationSearch: (search: string) => void;
   setSelectedAttributes: (attrs: string[]) => void;
-  setDataContext: (context: any) => void; // TODO this is not being used
+  setDataContext: (context: any) => void;
   setLocations: (locations: ILocation[]) => void;
 }
 
@@ -35,6 +35,7 @@ export const LocationTab: React.FC<LocationTabProps> = ({
   setLocations
 }) => {
 
+
   const {
     dataContext,
     handleClearData,
@@ -42,6 +43,8 @@ export const LocationTab: React.FC<LocationTabProps> = ({
     updateAttributeVisibility,
     getUniqueLocationsInCodapData
   } = useCodapData();
+
+  console.log("| what is dataContext anyway?", typeof dataContext, {dataContext});
 
   useEffect(() => {
     const updateEachAttrVisibility = () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -122,6 +122,15 @@ export const kChildCollectionAttributes = [
     title: "Season",
     type: "categorical",
     hasToken: true
+  },
+  {
+    name: "calcId",
+    title: "calcId",
+    type: "categorical",
+    hasToken: true,
+    hidden: false,
+    description: "unique identifier for each location on a day - concatenation of latitude, longitude, and dayOfYear",
+    formula: "latitude + ',' + longitude + ',' + dayOfYear"
   }
 ];
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,8 +53,8 @@ export const kChildCollectionAttributes = [
     name: "dayOfYear",
     title: "Day of year",
     type: "numeric",
-    // TODO: when not in dev, hasToken should be false, hidden should be true
-    hasToken: true,
+    hasToken: false,
+    hidden: true,
     description: "Day of year"
   },
   {
@@ -127,15 +127,15 @@ export const kChildCollectionAttributes = [
     name: "calcId",
     title: "calcId",
     type: "categorical",
-    hasToken: true,
-    hidden: false,
+    hasToken: false,
+    hidden: true,
     description: "unique identifier for each location on a day - concatenation of latitude, longitude, and dayOfYear",
     formula: "latitude + ',' + longitude + ',' + dayOfYear"
   }
 ];
 
 export const kDefaultOnAttributes = [
-  "date", "Day length", "dayOfYear" // TODO: take off dayOfYear when done with development
+  "date", "Day length"
 ];
 
 export const kDateWithTimeFormats = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,6 +50,14 @@ export const kChildCollectionAttributes = [
     description: "Date"
   },
   {
+    name: "dayOfYear",
+    title: "Day of year",
+    type: "numeric",
+    // TODO: when not in dev, hasToken should be false, hidden should be true
+    hasToken: true,
+    description: "Day of year"
+  },
+  {
     name: "Day length",
     title: "Day length",
     type: "numeric",
@@ -118,7 +126,7 @@ export const kChildCollectionAttributes = [
 ];
 
 export const kDefaultOnAttributes = [
-  "date", "Day length"
+  "date", "Day length", "dayOfYear" // TODO: take off dayOfYear when done with development
 ];
 
 export const kDateWithTimeFormats = {

--- a/src/grasp-seasons/components/seasons.tsx
+++ b/src/grasp-seasons/components/seasons.tsx
@@ -182,6 +182,7 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
     setSimState(prevState => {
       // Make sure day is within [0, 364] range
       const day = (prevState.day + increment + 365) % 365;
+      setDayOfYear(day);
       return { ...prevState, day };
     });
   };
@@ -189,6 +190,7 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
   const handleMonthIncrement = (monthIncrement: number) => () => {
     setSimState(prevState => {
       const day = changeMonthOfDayOfYear(prevState.day, monthIncrement);
+      setDayOfYear(day);
       return { ...prevState, day };
     });
   };

--- a/src/grasp-seasons/components/seasons.tsx
+++ b/src/grasp-seasons/components/seasons.tsx
@@ -201,7 +201,7 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
   const handleLatSliderChange = (event: any, ui: any) => {
     setSimState(prevState => ({ ...prevState, lat: ui.value }));
     setLatitude(formatLatLongNumber(ui.value));
-    // setLocationSearch("");
+    setLocationSearch("");
   };
 
   const handleLatInputChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -211,17 +211,14 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
 
   const handleLatIncrement = (increment: number) => () => {
     setSimState(prevState => ({ ...prevState, lat: prevState.lat + increment }));
-    // TODO: commenting these out prevents the "glitch"
-    // but lets test other examples of these being called and see if they are glitchy
-    // there might be something circular going on?
-    //setLatitude(formatLatLongNumber(simState.lat + increment));
-    //setLocationSearch("");
+    setLatitude(formatLatLongNumber(simState.lat + increment));
+    setLocationSearch("");
   }
 
   const handleLongSliderChange = (event: any, ui: any) => {
     setSimState(prevState => ({ ...prevState, long: ui.value }));
-    //setLongitude(formatLatLongNumber(ui.value));
-    //setLocationSearch("");
+    setLongitude(formatLatLongNumber(ui.value));
+    setLocationSearch("");
   };
 
   const handleLongInputChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/grasp-seasons/components/seasons.tsx
+++ b/src/grasp-seasons/components/seasons.tsx
@@ -201,7 +201,7 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
   const handleLatSliderChange = (event: any, ui: any) => {
     setSimState(prevState => ({ ...prevState, lat: ui.value }));
     setLatitude(formatLatLongNumber(ui.value));
-    setLocationSearch("");
+    // setLocationSearch("");
   };
 
   const handleLatInputChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -211,14 +211,17 @@ const Seasons: React.FC<IProps> = ({ lang = "en_us", initialState = {}, log = (a
 
   const handleLatIncrement = (increment: number) => () => {
     setSimState(prevState => ({ ...prevState, lat: prevState.lat + increment }));
-    setLatitude(formatLatLongNumber(simState.lat + increment));
-    setLocationSearch("");
+    // TODO: commenting these out prevents the "glitch"
+    // but lets test other examples of these being called and see if they are glitchy
+    // there might be something circular going on?
+    //setLatitude(formatLatLongNumber(simState.lat + increment));
+    //setLocationSearch("");
   }
 
   const handleLongSliderChange = (event: any, ui: any) => {
     setSimState(prevState => ({ ...prevState, long: ui.value }));
-    setLongitude(formatLatLongNumber(ui.value));
-    setLocationSearch("");
+    //setLongitude(formatLatLongNumber(ui.value));
+    //setLocationSearch("");
   };
 
   const handleLongInputChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/grasp-seasons/utils/utils.ts
+++ b/src/grasp-seasons/utils/utils.ts
@@ -72,3 +72,20 @@ export default function getURLParam(name: string, defaultValue = null) {
   if (value === "false") return false;
   return value;
 }
+
+export function debounce<T extends (...args: any[]) => any>(
+  func: T,
+  delay: number
+): (...args: Parameters<T>) => void {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  return function (this: any, ...args: Parameters<T>) {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+
+    timeoutId = setTimeout(() => {
+      func.apply(this, args);
+    }, delay);
+  };
+}

--- a/src/hooks/useCodapData.ts
+++ b/src/hooks/useCodapData.ts
@@ -34,12 +34,11 @@ export const useCodapData = () => {
   };
 
   const getDayLengthData = async (location: ILocation) => {
-    debugger;
     let createDC;
     const calcOptions: DaylightCalcOptions = {
       latitude: location.latitude,
       longitude: location.longitude,
-      year: 2024 // NOTE: If data are to be historical, add dynamic year attribute
+      year: new Date().getFullYear()
     };
 
     const solarEvents = getDayLightInfo(calcOptions);
@@ -119,7 +118,6 @@ export const useCodapData = () => {
 
     return uniqueLocations;
   }
-
 
   const getUniqueLocationsInCodapData = async () => {
     const locationAttr = await getAttribute(kDataContextName, kParentCollectionName, "location");

--- a/src/hooks/useCodapData.ts
+++ b/src/hooks/useCodapData.ts
@@ -67,6 +67,7 @@ export const useCodapData = () => {
           longitude: location.longitude,
           location: location.name,
           date: solarEvent.day,
+          dayOfYear: solarEvent.dayOfYear,
           rawSunrise: solarEvent.rawSunrise,
           rawSunset: solarEvent.rawSunset,
           "Day length": solarEvent.dayLength,

--- a/src/hooks/useCodapData.ts
+++ b/src/hooks/useCodapData.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { kDataContextName, kChildCollectionName, kParentCollectionName, kParentCollectionAttributes, kChildCollectionAttributes } from "../constants";
 import { DaylightCalcOptions, ILocation } from "../types";
 import { getDayLightInfo, locationsEqual } from "../utils/daylight-utils";
@@ -23,6 +23,7 @@ export const useCodapData = () => {
     if (result.success) {
       let dc = result.values;
       let lastCollection = dc.collections[dc.collections.length - 1];
+      console.trace();
       return await codapInterface.sendRequest({
         action: "delete",
         resource: `dataContext[${kDataContextName}].collection[${lastCollection.name}].allCases`
@@ -33,6 +34,7 @@ export const useCodapData = () => {
   };
 
   const getDayLengthData = async (location: ILocation) => {
+    debugger;
     let createDC;
     const calcOptions: DaylightCalcOptions = {
       latitude: location.latitude,
@@ -84,7 +86,7 @@ export const useCodapData = () => {
     }
   };
 
-  const updateAttributeVisibility = (attributeName: string, hidden: boolean) => {
+  const updateAttributeVisibility = useCallback((attributeName: string, hidden: boolean) => {
     if (!dataContext) return;
 
     try {
@@ -98,7 +100,7 @@ export const useCodapData = () => {
     } catch (error) {
       console.error("Error updating attribute visibility:", error);
     }
-  };
+  }, [dataContext]);
 
   const extractUniqueLocations = (allItems: any): ILocation[] => {
     const uniqueLocations: ILocation[] = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,14 @@
+export interface ICodapDataContextInfo {
+  id: number;
+  name: string;
+  title: string;
+}
+
+export interface ICurrentDayLocation {
+  _latitude: string;
+  _longitude: string;
+  _dayOfYear: number;
+}
 
 export interface ILocation {
   name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface DaylightCalcOptions {
 
 export interface DaylightInfo {
   day: string;          // read into CODAP as an ISO date
+  dayOfYear: number;
   rawSunrise: string;   // read into CODAP as an ISO date
   rawSunset: string;    // read into CODAP as an ISO date
   dayLength: number;

--- a/src/utils/daylight-utils.ts
+++ b/src/utils/daylight-utils.ts
@@ -89,7 +89,7 @@ export function getSolarNoonIntensity(dayNum: number, latitude: number): number 
   // Negative values are clamped to zero, which
   // represents times when the sun is below the horizon
   // In reality, some diffuse light might still be present due to atmospheric scattering.
-  // None of the calculations in this plugin use "civil twighlight" or associated definitions
+  // None of the calculations in this plugin use "civil twilight" or associated definitions
   // For day length either, so this is consistent with the rest of the calculations.
   return Math.max(0, solarNoonIntensity);
 }
@@ -154,6 +154,7 @@ export function getDayLightInfo(options: DaylightCalcOptions): DaylightInfo[] {
 
     const record: DaylightInfo = {
       day: currentDay.format(kDateFormats.asLocalISODate),
+      dayOfYear: currentDay.dayOfYear(),
       rawSunrise: localSunriseObj.format(kDateWithTimeFormats.asLocalISOWithTZOffset),
       rawSunset: localSunsetObj.format(kDateWithTimeFormats.asLocalISOWithTZOffset),
       dayLength: finalDayLength,


### PR DESCRIPTION
[PT-187887881](https://www.pivotaltracker.com/story/show/187887881) Selected Row Sync
[PT-188109247](https://www.pivotaltracker.com/story/show/188109247) When Sim is accessed, it moves to the front

- when sim selects a particular day, selected row is updated in CODAP
- when a row is selected in CODAP, the earth in the sim moves to the corresponding spot
- when a case is deleted in codap, the locations array is updated - note that there is a path/note here to add that functionality to location string update on CODAP side
- adds a general debounce function, right now only used to wrap day slider change handler 
- adds a hidden field in CODAP that concats lat, long, day so we can select across child collections using `.caseSearch`