### PR TITLE
feat: Enable simulation tab at startup [PT-188182370]

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -49,13 +49,8 @@ export const App: React.FC = () => {
   const [locations, setLocations] = useState<ILocation[]>([]);
   const [locationSearch, setLocationSearch] = useState<string>("");
   const [selectedAttrs, setSelectedAttributes] = useState<string[]>(kDefaultOnAttributes);
-  const [simEnabled, setSimEnabled] = useState(false);
 
   const { getDayLengthData, dataContext, getUniqueLocationsInCodapData } = useCodapData();
-
-  useEffect(() => {
-    setSimEnabled(!!dataContext);
-  }, [dataContext]);
 
   const currentDayLocationRef = useRef<ICurrentDayLocation>({
     _latitude: "",
@@ -150,8 +145,6 @@ export const App: React.FC = () => {
   }, [latitude, longitude, dayOfYear]);
 
   const handleTabClick = (tab: TabName) => {
-    // comment out next line during development
-    if (tab === "simulation" && !simEnabled) return;
     setActiveTab(tab);
     codapInterface.sendRequest({
       action: "update",
@@ -187,7 +180,6 @@ export const App: React.FC = () => {
       <Header
         activeTab={activeTab}
         onTabClick={handleTabClick}
-        showEnabled={simEnabled}
       />
       <div className={clsx("tab-content", { active: activeTab === "location" })}>
         <LocationTab

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -6,10 +6,9 @@ import "./header.scss";
 interface IHeaderProps {
   activeTab: TabName;
   onTabClick: (tab: TabName) => void;
-  showEnabled: boolean;
 }
 
-export const Header: React.FC<IHeaderProps> = ({ activeTab, onTabClick, showEnabled }) => {
+export const Header: React.FC<IHeaderProps> = ({ activeTab, onTabClick }) => {
   return (
     <div className="tab-container">
       <div
@@ -19,7 +18,7 @@ export const Header: React.FC<IHeaderProps> = ({ activeTab, onTabClick, showEnab
         Location
       </div>
       <div
-        className={`tab simulation ${activeTab === "simulation" ? "active" : ""} ${showEnabled ? "" : "disabled"}`}
+        className={`tab simulation ${activeTab === "simulation" ? "active" : ""}`}
         onClick={() => onTabClick("simulation")}
       >
         Simulation


### PR DESCRIPTION
Per request of the PI this removes the code that disabled the simulation tab until the data was available in CODAP in the data context.